### PR TITLE
When an exception is caught call _resetRequest

### DIFF
--- a/src/RapidSpike/API/Client.php
+++ b/src/RapidSpike/API/Client.php
@@ -251,7 +251,7 @@ class Client
 
             // Re-throw this exception to allow us to reset the request
             // so that the client object can continue to be used
-            $this->resetRequest();
+            $this->_resetRequest();
             throw $error;
         }
     }


### PR DESCRIPTION
This corrects an issue with an undefined method.

As this doesn't fire, it caused a chain of URLs to be generated and snowballed the size of the URL